### PR TITLE
Backend flushes data when stream ends

### DIFF
--- a/data_reader.go
+++ b/data_reader.go
@@ -30,6 +30,9 @@ type StringReader interface {
 type DataRow struct {
 	X  float64
 	Ys []float64
+
+	streamEnded bool
+	streamErr   error
 }
 
 // When Read is called, return the DataRow.


### PR DESCRIPTION
The timestamp parsing is currently broken and needs to be fixed because the data is expected to be unix millis as opposed to unix seconds.